### PR TITLE
Fix CORS and cleanup warning

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -7,7 +7,9 @@ const path = require('path');
 const app = express();
 const PORT = process.env.PORT || 5000;
 
+// Enable CORS for all routes including preflight requests
 app.use(cors());
+app.options('*', cors());
 app.use(fileUpload());
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 app.use('/api', apiRoutes);

--- a/frontend/src/components/PdfViewer.js
+++ b/frontend/src/components/PdfViewer.js
@@ -10,7 +10,6 @@ import {
   FaArrowLeft,
   FaArrowRight,
   FaExpand,
-  FaFileUpload,
 } from 'react-icons/fa';
 
 import '@react-pdf-viewer/core/lib/styles/index.css';


### PR DESCRIPTION
## Summary
- enable handling of CORS preflight requests in the Express backend
- remove an unused icon import from PdfViewer

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test -- --watchAll=false` in `frontend` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684069a7feb88331bea82eac8689c1f8